### PR TITLE
DocumentAssembler abstraction to support alternative data sources

### DIFF
--- a/OpenXmlPowerTools.Tests/DocumentAssemblerAsyncTests.cs
+++ b/OpenXmlPowerTools.Tests/DocumentAssemblerAsyncTests.cs
@@ -1,0 +1,243 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+using System.Xml.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Validation;
+using OpenXmlPowerTools;
+using Xunit;
+
+#if !ELIDE_XUNIT_TESTS
+
+namespace OxPt
+{
+    public class DaaTests
+    {
+        [Theory]
+        [InlineData("DA001-TemplateDocument.docx", "DA-Data.xml", false)]
+        [InlineData("DA002-TemplateDocument.docx", "DA-DataNotHighValueCust.xml", false)]
+        [InlineData("DA003-Select-XPathFindsNoData.docx", "DA-Data.xml", true)]
+        [InlineData("DA004-Select-XPathFindsNoDataOptional.docx", "DA-Data.xml", false)]
+        [InlineData("DA005-SelectRowData-NoData.docx", "DA-Data.xml", true)]
+        [InlineData("DA006-SelectTestValue-NoData.docx", "DA-Data.xml", true)]
+        [InlineData("DA007-SelectRepeatingData-NoData.docx", "DA-Data.xml", true)]
+        [InlineData("DA008-TableElementWithNoTable.docx", "DA-Data.xml", true)]
+        [InlineData("DA009-InvalidXPath.docx", "DA-Data.xml", true)]
+        [InlineData("DA010-InvalidXml.docx", "DA-Data.xml", true)]
+        [InlineData("DA011-SchemaError.docx", "DA-Data.xml", true)]
+        [InlineData("DA012-OtherMarkupTypes.docx", "DA-Data.xml", true)]
+        [InlineData("DA013-Runs.docx", "DA-Data.xml", false)]
+        [InlineData("DA014-TwoRuns-NoValuesSelected.docx", "DA-Data.xml", true)]
+        [InlineData("DA015-TwoRunsXmlExceptionInFirst.docx", "DA-Data.xml", true)]
+        [InlineData("DA016-TwoRunsSchemaErrorInSecond.docx", "DA-Data.xml", true)]
+        [InlineData("DA017-FiveRuns.docx", "DA-Data.xml", true)]
+        [InlineData("DA018-SmartQuotes.docx", "DA-Data.xml", false)]
+        [InlineData("DA019-RunIsEntireParagraph.docx", "DA-Data.xml", false)]
+        [InlineData("DA020-TwoRunsAndNoOtherContent.docx", "DA-Data.xml", true)]
+        [InlineData("DA021-NestedRepeat.docx", "DA-DataNestedRepeat.xml", false)]
+        [InlineData("DA022-InvalidXPath.docx", "DA-Data.xml", true)]
+        [InlineData("DA023-RepeatWOEndRepeat.docx", "DA-Data.xml", true)]
+        [InlineData("DA026-InvalidRootXmlElement.docx", "DA-Data.xml", true)]
+        [InlineData("DA027-XPathErrorInPara.docx", "DA-Data.xml", true)]
+        [InlineData("DA028-NoPrototypeRow.docx", "DA-Data.xml", true)]
+        [InlineData("DA029-NoDataForCell.docx", "DA-Data.xml", true)]
+        [InlineData("DA030-TooMuchDataForCell.docx", "DA-TooMuchDataForCell.xml", true)]
+        [InlineData("DA031-CellDataInAttributes.docx", "DA-CellDataInAttributes.xml", true)]
+        [InlineData("DA032-TooMuchDataForConditional.docx", "DA-TooMuchDataForConditional.xml", true)]
+        [InlineData("DA033-ConditionalOnAttribute.docx", "DA-ConditionalOnAttribute.xml", false)]
+        [InlineData("DA034-HeaderFooter.docx", "DA-Data.xml", false)]
+        [InlineData("DA035-SchemaErrorInRepeat.docx", "DA-Data.xml", true)]
+        [InlineData("DA036-SchemaErrorInConditional.docx", "DA-Data.xml", true)]
+
+        [InlineData("DA100-TemplateDocument.docx", "DA-Data.xml", false)]
+        [InlineData("DA101-TemplateDocument.docx", "DA-Data.xml", true)]
+        [InlineData("DA102-TemplateDocument.docx", "DA-Data.xml", true)]
+
+        [InlineData("DA201-TemplateDocument.docx", "DA-Data.xml", false)]
+        [InlineData("DA202-TemplateDocument.docx", "DA-DataNotHighValueCust.xml", false)]
+        [InlineData("DA203-Select-XPathFindsNoData.docx", "DA-Data.xml", true)]
+        [InlineData("DA204-Select-XPathFindsNoDataOptional.docx", "DA-Data.xml", false)]
+        [InlineData("DA205-SelectRowData-NoData.docx", "DA-Data.xml", true)]
+        [InlineData("DA206-SelectTestValue-NoData.docx", "DA-Data.xml", true)]
+        [InlineData("DA207-SelectRepeatingData-NoData.docx", "DA-Data.xml", true)]
+        [InlineData("DA209-InvalidXPath.docx", "DA-Data.xml", true)]
+        [InlineData("DA210-InvalidXml.docx", "DA-Data.xml", true)]
+        [InlineData("DA211-SchemaError.docx", "DA-Data.xml", true)]
+        [InlineData("DA212-OtherMarkupTypes.docx", "DA-Data.xml", true)]
+        [InlineData("DA213-Runs.docx", "DA-Data.xml", false)]
+        [InlineData("DA214-TwoRuns-NoValuesSelected.docx", "DA-Data.xml", true)]
+        [InlineData("DA215-TwoRunsXmlExceptionInFirst.docx", "DA-Data.xml", true)]
+        [InlineData("DA216-TwoRunsSchemaErrorInSecond.docx", "DA-Data.xml", true)]
+        [InlineData("DA217-FiveRuns.docx", "DA-Data.xml", true)]
+        [InlineData("DA218-SmartQuotes.docx", "DA-Data.xml", false)]
+        [InlineData("DA219-RunIsEntireParagraph.docx", "DA-Data.xml", false)]
+        [InlineData("DA220-TwoRunsAndNoOtherContent.docx", "DA-Data.xml", true)]
+        [InlineData("DA221-NestedRepeat.docx", "DA-DataNestedRepeat.xml", false)]
+        [InlineData("DA222-InvalidXPath.docx", "DA-Data.xml", true)]
+        [InlineData("DA223-RepeatWOEndRepeat.docx", "DA-Data.xml", true)]
+        [InlineData("DA226-InvalidRootXmlElement.docx", "DA-Data.xml", true)]
+        [InlineData("DA227-XPathErrorInPara.docx", "DA-Data.xml", true)]
+        [InlineData("DA228-NoPrototypeRow.docx", "DA-Data.xml", true)]
+        [InlineData("DA229-NoDataForCell.docx", "DA-Data.xml", true)]
+        [InlineData("DA230-TooMuchDataForCell.docx", "DA-TooMuchDataForCell.xml", true)]
+        [InlineData("DA231-CellDataInAttributes.docx", "DA-CellDataInAttributes.xml", true)]
+        [InlineData("DA232-TooMuchDataForConditional.docx", "DA-TooMuchDataForConditional.xml", true)]
+        [InlineData("DA233-ConditionalOnAttribute.docx", "DA-ConditionalOnAttribute.xml", false)]
+        [InlineData("DA234-HeaderFooter.docx", "DA-Data.xml", false)]
+        [InlineData("DA235-Crashes.docx", "DA-Content-List.xml", false)]
+        [InlineData("DA236-Page-Num-in-Footer.docx", "DA-Content-List.xml", false)]
+        [InlineData("DA237-SchemaErrorInRepeat.docx", "DA-Data.xml", true)]
+        [InlineData("DA238-SchemaErrorInConditional.docx", "DA-Data.xml", true)]
+        [InlineData("DA239-RunLevelCC-Repeat.docx", "DA-Data.xml", false)]
+
+        [InlineData("DA250-ConditionalWithRichXPath.docx", "DA250-Address.xml", false)]
+        [InlineData("DA251-EnhancedTables.docx", "DA-Data.xml", false)]
+        [InlineData("DA252-Table-With-Sum.docx", "DA-Data.xml", false)]
+        [InlineData("DA253-Table-With-Sum-Run-Level-CC.docx", "DA-Data.xml", false)]
+        [InlineData("DA254-Table-With-XPath-Sum.docx", "DA-Data.xml", false)]
+        [InlineData("DA255-Table-With-XPath-Sum-Run-Level-CC.docx", "DA-Data.xml", false)]
+        [InlineData("DA256-NoInvalidDocOnErrorInRun.docx", "DA-Data.xml", true)]
+        [InlineData("DA257-OptionalRepeat.docx", "DA-Data.xml", false)]
+        [InlineData("DA258-ContentAcceptsCharsAsXPathResult.docx", "DA-Data.xml", false)]
+        [InlineData("DA259-MultiLineContents.docx", "DA-Data.xml", false)]
+        [InlineData("DA260-RunLevelRepeat.docx", "DA-Data.xml", false)]
+        [InlineData("DA261-RunLevelConditional.docx", "DA-Data.xml", false)]
+        [InlineData("DA262-ConditionalNotMatch.docx", "DA-Data.xml", false)]
+        [InlineData("DA263-ConditionalNotMatch.docx", "DA-DataSmallCustomer.xml", false)]
+        [InlineData("DA264-InvalidRunLevelRepeat.docx", "DA-Data.xml", true)]
+        [InlineData("DA265-RunLevelRepeatWithWhiteSpaceBefore.docx", "DA-Data.xml", false)]
+        [InlineData("DA266-RunLevelRepeat-NoData.docx", "DA-Data.xml", true)]
+        
+        public async Task DA101(string name, string data, bool err)
+        {
+            DirectoryInfo sourceDir = new DirectoryInfo("../../../../TestFiles/");
+            FileInfo templateDocx = new FileInfo(Path.Combine(sourceDir.FullName, name));
+            FileInfo dataFile = new FileInfo(Path.Combine(sourceDir.FullName, data));
+
+            WmlDocument wmlTemplate = new WmlDocument(templateDocx.FullName);
+            XElement xmldata = XElement.Load(dataFile.FullName);
+
+            (WmlDocument afterAssembling, bool returnedTemplateError) =
+                await DocumentAssembler.AssembleDocumentAsync(wmlTemplate, xmldata);
+            var assembledDocx = new FileInfo(Path.Combine(TestUtil.TempDir.FullName, templateDocx.Name.Replace(".docx", "-processed-by-DocumentAssembler-async.docx")));
+            afterAssembling.SaveAs(assembledDocx.FullName);
+
+            using (MemoryStream ms = new MemoryStream())
+            {
+                ms.Write(afterAssembling.DocumentByteArray, 0, afterAssembling.DocumentByteArray.Length);
+                using (WordprocessingDocument wDoc = WordprocessingDocument.Open(ms, true))
+                {
+                    OpenXmlValidator v = new OpenXmlValidator();
+                    var valErrors = v.Validate(wDoc).Where(ve => !s_ExpectedErrors.Contains(ve.Description));
+
+#if false
+                    StringBuilder sb = new StringBuilder();
+                    foreach (var item in valErrors.Select(r => r.Description).OrderBy(t => t).Distinct())
+	                {
+		                sb.Append(item).Append(Environment.NewLine);
+	                }
+                    string z = sb.ToString();
+                    Console.WriteLine(z);
+#endif
+
+                    Assert.Empty(valErrors);
+                }
+            }
+
+            Assert.Equal(err, returnedTemplateError);
+        }
+
+        [Theory]
+        [InlineData("DA259-MultiLineContents.docx", "DA-Data.xml", false)]
+        public async Task DA259(string name, string data, bool err)
+        {
+            await DA101(name, data, err);
+            var assembledDocx = new FileInfo(Path.Combine(TestUtil.TempDir.FullName, name.Replace(".docx", "-processed-by-DocumentAssembler-async.docx")));
+            WmlDocument afterAssembling = new WmlDocument(assembledDocx.FullName);
+            int brCount = afterAssembling.MainDocumentPart
+                            .Element(W.body)
+                            .Elements(W.p).ElementAt(1)
+                            .Elements(W.r)
+                            .Elements(W.br).Count();
+            Assert.Equal(4, brCount);
+        }
+
+        [Theory]
+        [InlineData("DA024-TrackedRevisions.docx", "DA-Data.xml")]
+        public async Task DA102_Throws(string name, string data)
+        {
+            DirectoryInfo sourceDir = new DirectoryInfo("../../../../TestFiles/");
+            FileInfo templateDocx = new FileInfo(Path.Combine(sourceDir.FullName, name));
+            FileInfo dataFile = new FileInfo(Path.Combine(sourceDir.FullName, data));
+
+            WmlDocument wmlTemplate = new WmlDocument(templateDocx.FullName);
+            XElement xmldata = XElement.Load(dataFile.FullName);
+
+            await Assert.ThrowsAsync<OpenXmlPowerToolsException>(async () =>
+                {
+                    (WmlDocument afterAssembling, bool returnedTemplateError) =
+                        await DocumentAssembler.AssembleDocumentAsync(wmlTemplate, xmldata);
+                });
+        }
+
+        [Theory]
+        [InlineData("DA025-TemplateDocument.docx", "DA-Data.xml", false)]
+        public async Task DA103_UseXmlDocument(string name, string data, bool err)
+        {
+            DirectoryInfo sourceDir = new DirectoryInfo("../../../../TestFiles/");
+            FileInfo templateDocx = new FileInfo(Path.Combine(sourceDir.FullName, name));
+            FileInfo dataFile = new FileInfo(Path.Combine(sourceDir.FullName, data));
+
+            WmlDocument wmlTemplate = new WmlDocument(templateDocx.FullName);
+            XmlDocument xmldata = new XmlDocument();
+            xmldata.Load(dataFile.FullName);
+
+            (WmlDocument afterAssembling, bool returnedTemplateError) =
+                await DocumentAssembler.AssembleDocumentAsync(wmlTemplate, xmldata);
+            var assembledDocx = new FileInfo(Path.Combine(TestUtil.TempDir.FullName, templateDocx.Name.Replace(".docx", "-processed-by-DocumentAssembler-async.docx")));
+            afterAssembling.SaveAs(assembledDocx.FullName);
+
+            using (MemoryStream ms = new MemoryStream())
+            {
+                ms.Write(afterAssembling.DocumentByteArray, 0, afterAssembling.DocumentByteArray.Length);
+                using (WordprocessingDocument wDoc = WordprocessingDocument.Open(ms, true))
+                {
+                    OpenXmlValidator v = new OpenXmlValidator();
+                    var valErrors = v.Validate(wDoc).Where(ve => !s_ExpectedErrors.Contains(ve.Description));
+                    Assert.Empty(valErrors);
+                }
+            }
+
+            Assert.Equal(err, returnedTemplateError);
+        }
+
+        private static List<string> s_ExpectedErrors = new List<string>()
+        {
+            "The 'http://schemas.openxmlformats.org/wordprocessingml/2006/main:evenHBand' attribute is not declared.",
+            "The 'http://schemas.openxmlformats.org/wordprocessingml/2006/main:evenVBand' attribute is not declared.",
+            "The 'http://schemas.openxmlformats.org/wordprocessingml/2006/main:firstColumn' attribute is not declared.",
+            "The 'http://schemas.openxmlformats.org/wordprocessingml/2006/main:firstRow' attribute is not declared.",
+            "The 'http://schemas.openxmlformats.org/wordprocessingml/2006/main:firstRowFirstColumn' attribute is not declared.",
+            "The 'http://schemas.openxmlformats.org/wordprocessingml/2006/main:firstRowLastColumn' attribute is not declared.",
+            "The 'http://schemas.openxmlformats.org/wordprocessingml/2006/main:lastColumn' attribute is not declared.",
+            "The 'http://schemas.openxmlformats.org/wordprocessingml/2006/main:lastRow' attribute is not declared.",
+            "The 'http://schemas.openxmlformats.org/wordprocessingml/2006/main:lastRowFirstColumn' attribute is not declared.",
+            "The 'http://schemas.openxmlformats.org/wordprocessingml/2006/main:lastRowLastColumn' attribute is not declared.",
+            "The 'http://schemas.openxmlformats.org/wordprocessingml/2006/main:noHBand' attribute is not declared.",
+            "The 'http://schemas.openxmlformats.org/wordprocessingml/2006/main:noVBand' attribute is not declared.",
+            "The 'http://schemas.openxmlformats.org/wordprocessingml/2006/main:oddHBand' attribute is not declared.",
+            "The 'http://schemas.openxmlformats.org/wordprocessingml/2006/main:oddVBand' attribute is not declared.",
+        };
+    }
+}
+
+#endif

--- a/OpenXmlPowerTools/DocumentAssembler.cs
+++ b/OpenXmlPowerTools/DocumentAssembler.cs
@@ -19,7 +19,7 @@ using System.Collections;
 
 namespace OpenXmlPowerTools
 {
-    public class DocumentAssembler : DocumentAssemblerBase
+    public partial class DocumentAssembler : DocumentAssemblerBase
     {
         public static WmlDocument AssembleDocument(WmlDocument templateDoc, XmlDocument data, out bool templateError)
         {
@@ -44,7 +44,7 @@ namespace OpenXmlPowerTools
         }
     }
 
-    public class DocumentAssemblerBase
+    public partial class DocumentAssemblerBase
     {
         protected static bool AssembleDocument(WordprocessingDocument wordDoc, IDataContext data)
         {
@@ -631,32 +631,7 @@ namespace OpenXmlPowerTools
                     {
                         return CreateContextErrorMessage(element, "EvaluationException: " + e.Message, templateError);
                     }
-
-                    if (para != null)
-                    {
-
-                        XElement p = new XElement(W.p, para.Elements(W.pPr));
-                        foreach(string line in newValue.Split('\n'))
-                        {
-                            p.Add(new XElement(W.r,
-                                    para.Elements(W.r).Elements(W.rPr).FirstOrDefault(),
-                                (p.Elements().Count() > 1) ? new XElement(W.br) : null,
-                                new XElement(W.t, line)));
-                        }
-                        return p;
-                    }
-                    else
-                    {
-                        List<XElement> list = new List<XElement>();
-                        foreach(string line in newValue.Split('\n'))
-                        {
-                            list.Add(new XElement(W.r,
-                                run.Elements().Where(e => e.Name != W.t),
-                                (list.Count > 0) ? new XElement(W.br) : null,
-                                new XElement(W.t, line)));
-                        }
-                        return list;
-                    }
+                    return ReplaceValue(para, run, newValue);
                 }
                 if (element.Name == PA.Repeat)
                 {
@@ -788,6 +763,34 @@ namespace OpenXmlPowerTools
                     element.Nodes().Select(n => ContentReplacementTransform(n, data, templateError)));
             }
             return node;
+        }
+
+        private static object ReplaceValue(XElement para, XElement run, string newValue)
+        {
+            if (para != null)
+            {
+                XElement p = new XElement(W.p, para.Elements(W.pPr));
+                foreach (string line in newValue.Split('\n'))
+                {
+                    p.Add(new XElement(W.r,
+                            para.Elements(W.r).Elements(W.rPr).FirstOrDefault(),
+                        (p.Elements().Count() > 1) ? new XElement(W.br) : null,
+                        new XElement(W.t, line)));
+                }
+                return p;
+            }
+            else
+            {
+                List<XElement> list = new List<XElement>();
+                foreach (string line in newValue.Split('\n'))
+                {
+                    list.Add(new XElement(W.r,
+                        run.Elements().Where(e => e.Name != W.t),
+                        (list.Count > 0) ? new XElement(W.br) : null,
+                        new XElement(W.t, line)));
+                }
+                return list;
+            }
         }
 
         private static object CreateContextErrorMessage(XElement element, string errorMessage, TemplateError templateError)

--- a/OpenXmlPowerTools/DocumentAssemblerAsync.cs
+++ b/OpenXmlPowerTools/DocumentAssemblerAsync.cs
@@ -1,0 +1,376 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml;
+using System.Xml.Linq;
+using System.Xml.XPath;
+using System.Threading.Tasks;
+using DocumentFormat.OpenXml.Packaging;
+
+namespace OpenXmlPowerTools
+{
+    public partial class DocumentAssembler : DocumentAssemblerBase
+    {
+        public static Task<AssembleResult> AssembleDocumentAsync(WmlDocument templateDoc, XmlDocument data)
+        {
+            XDocument xDoc = data.GetXDocument();
+            return AssembleDocumentAsync(templateDoc, xDoc.Root);
+        }
+
+        public static async Task<AssembleResult> AssembleDocumentAsync(WmlDocument templateDoc, XElement data)
+        {
+            var dataSource = new AsyncXmlDataContext(data);
+            byte[] byteArray = templateDoc.DocumentByteArray;
+            bool templateError = false;
+            using (MemoryStream mem = new MemoryStream())
+            {
+                mem.Write(byteArray, 0, (int)byteArray.Length);
+                using (WordprocessingDocument wordDoc = WordprocessingDocument.Open(mem, true))
+                {
+                    templateError = await AssembleDocumentAsync(wordDoc, dataSource);
+                }
+                return new AssembleResult(new WmlDocument("TempFileName.docx", mem.ToArray()), templateError);
+            }
+        }
+    }
+
+    public partial class DocumentAssemblerBase
+    {
+        protected static async Task<bool> AssembleDocumentAsync(WordprocessingDocument wordDoc, IAsyncDataContext data)
+        {
+            if (RevisionAccepter.HasTrackedRevisions(wordDoc))
+                throw new OpenXmlPowerToolsException("Invalid DocumentAssembler template - contains tracked revisions");
+
+            var te = new TemplateError();
+            var partTasks = wordDoc.ContentParts().Select(part => ProcessTemplatePartAsync(data, te, part));
+            await Task.WhenAll(partTasks);
+            return te.HasError;
+        }
+
+        protected static async Task<AssembleResult> AssembleDocumentAsync(WmlDocument templateDoc, string outputFilename, IAsyncDataContext dataSource)
+        {
+            WmlDocument assembledDocument = null;
+            bool templateError = false;
+            byte[] byteArray = templateDoc.DocumentByteArray;
+            using (MemoryStream mem = new MemoryStream())
+            {
+                mem.Write(byteArray, 0, (int)byteArray.Length); // copy template file (binary) into memory -- I guess so the template/file handle isn't held/locked?
+                using (WordprocessingDocument wordDoc = WordprocessingDocument.Open(mem, true)) // read & parse that byte array into OXML document (also in memory)
+                {
+                    templateError = await AssembleDocumentAsync(wordDoc, dataSource);
+                }
+                assembledDocument = new WmlDocument(outputFilename, mem.ToArray());
+            }
+            return new AssembleResult(assembledDocument, templateError);
+        }
+
+        protected static async Task<bool> PrepareTemplateAsync(WordprocessingDocument wordDoc, IMetadataParser fieldParser)
+        {
+            if (RevisionAccepter.HasTrackedRevisions(wordDoc))
+                throw new OpenXmlPowerToolsException("Invalid DocumentAssembler template - contains tracked revisions");
+
+            await Task.Yield(); // force asynchrony (for testing, mostly)
+
+            var te = new TemplateError();
+            foreach (var part in wordDoc.ContentParts())
+            {
+                XDocument xDoc = part.GetXDocument();
+                xDoc.Elements().First().ReplaceWith(PrepareTemplatePart(fieldParser, te, xDoc.Root));
+                part.PutXDocument(); // if we were processing template parts in parallel (as we do during assembly), this would need to be lock{}ed
+            }
+            return te.HasError;
+        }
+        private static readonly object s_partLock = new object();
+
+        private static async Task ProcessTemplatePartAsync(IAsyncDataContext data, TemplateError te, OpenXmlPart part)
+        {
+            XDocument xDoc = part.GetXDocument();
+            var xDocRoot = PrepareTemplatePart(data, te, xDoc.Root);
+
+            // do the actual content replacement
+            xDocRoot = (XElement)await ContentReplacementTransformAsync(xDocRoot, data, te);
+
+            xDoc.Elements().First().ReplaceWith(xDocRoot);
+            // work around apparent issues with thread safety when replacing the content of a part within a package
+            lock (s_partLock)
+            {
+                part.PutXDocument();
+            }
+        }
+
+        static async Task<object> ContentReplacementTransformAsync(XNode node, IAsyncDataContext data, TemplateError templateError)
+        {
+            XElement element = node as XElement;
+            if (element != null)
+            {
+                if (element.Name == PA.Content)
+                {
+                    XElement para = element.Descendants(W.p).FirstOrDefault();
+                    XElement run = element.Descendants(W.r).FirstOrDefault();
+
+                    var selector = (string)element.Attribute(PA.Select);
+                    var optionalString = (string)element.Attribute(PA.Optional);
+                    bool optional = (optionalString != null && optionalString.ToLower() == "true");
+
+                    string newValue;
+                    try
+                    {
+                        newValue = await data.EvaluateTextAsync(selector, optional);
+                    }
+                    catch (EvaluationException e)
+                    {
+                        return CreateContextErrorMessage(element, "EvaluationException: " + e.Message, templateError);
+                    }
+
+                    return ReplaceValue(para, run, newValue);
+                }
+                if (element.Name == PA.Repeat)
+                {
+                    string selector = (string)element.Attribute(PA.Select);
+                    var optionalString = (string)element.Attribute(PA.Optional);
+                    bool optional = (optionalString != null && optionalString.ToLower() == "true");
+
+                    IAsyncDataContext[] repeatingData;
+                    try
+                    {
+                        repeatingData = await data.EvaluateListAsync(selector, optional);
+                    }
+                    catch (EvaluationException e)
+                    {
+                        return CreateContextErrorMessage(element, "EvaluationException: " + e.Message, templateError);
+                    }
+                    if (!repeatingData.Any())
+                    {
+                        return null;
+                        //XElement para = element.Descendants(W.p).FirstOrDefault();
+                        //if (para != null)
+                        //    return new XElement(W.p, new XElement(W.r));
+                        //else
+                        //    return new XElement(W.r);
+                    }
+                    var newContentTasks = repeatingData.Select(async d =>
+                        {
+                            var contentTasks = element
+                                .Elements()
+                                .Select(e => ContentReplacementTransformAsync(e, d, templateError));
+                            var content = await Task.WhenAll(contentTasks);
+                            await d.ReleaseAsync();
+                            return content;
+                        });
+                    var newContent = await Task.WhenAll(newContentTasks);
+                    return newContent;
+                }
+                if (element.Name == PA.Table)
+                {
+                    IAsyncDataContext[] tableData;
+                    try
+                    {
+                        tableData = await data.EvaluateListAsync((string)element.Attribute(PA.Select), true);
+                    }
+                    catch (EvaluationException e)
+                    {
+                        return CreateContextErrorMessage(element, "EvaluationException: " + e.Message, templateError);
+                    }
+                    if (tableData.Count() == 0)
+                        return CreateContextErrorMessage(element, "Table Select returned no data", templateError);
+                    XElement table = element.Element(W.tbl);
+                    XElement protoRow = table.Elements(W.tr).Skip(1).FirstOrDefault();
+                    var footerRowsBeforeTransform = table
+                        .Elements(W.tr)
+                        .Skip(2)
+                        .ToList();
+                    var footerRowTasks = footerRowsBeforeTransform
+                        .Select(x => ContentReplacementTransformAsync(x, data, templateError));
+                    var footerRows = await Task.WhenAll(footerRowTasks);
+                    if (protoRow == null)
+                        return CreateContextErrorMessage(element, string.Format("Table does not contain a prototype row"), templateError);
+                    protoRow.Descendants(W.bookmarkStart).Remove();
+                    protoRow.Descendants(W.bookmarkEnd).Remove();
+                    var dataRowTasks = tableData.Select(async d =>
+                        {
+                            var cellTasks = protoRow.Elements(W.tc)
+                                .Select(async tc =>
+                                {
+                                    XElement paragraph = tc.Elements(W.p).FirstOrDefault();
+                                    XElement cellRun = paragraph.Elements(W.r).FirstOrDefault();
+                                    string selector = paragraph.Value;
+                                    string newValue = null;
+                                    try
+                                    {
+                                        newValue = await d.EvaluateTextAsync(selector, false);
+                                    }
+                                    catch (EvaluationException e)
+                                    {
+                                        XElement errorCell = new XElement(W.tc,
+                                            tc.Elements().Where(z => z.Name != W.p),
+                                            new XElement(W.p,
+                                                paragraph.Element(W.pPr),
+                                                CreateRunErrorMessage(e.Message, templateError)));
+                                        return errorCell;
+                                    }
+
+                                    XElement newCell = new XElement(W.tc,
+                                        tc.Elements().Where(z => z.Name != W.p),
+                                        new XElement(W.p,
+                                            paragraph.Element(W.pPr),
+                                            new XElement(W.r,
+                                                cellRun != null ? cellRun.Element(W.rPr) : new XElement(W.rPr),  //if the cell was empty there is no cellrun
+                                                new XElement(W.t, newValue))));
+                                    return newCell;
+                                });
+                            var rowContent = new XElement(W.tr,
+                                protoRow.Elements().Where(r => r.Name != W.tc),
+                                await Task.WhenAll(cellTasks));
+                            await d.ReleaseAsync();
+                            return rowContent;
+                        });
+                    XElement newTable = new XElement(W.tbl,
+                        table.Elements().Where(e => e.Name != W.tr),
+                        table.Elements(W.tr).FirstOrDefault(),
+                        await Task.WhenAll(dataRowTasks),
+                        footerRows
+                        );
+                    return newTable;
+                }
+                if (element.Name == PA.Conditional)
+                {
+                    string selector = (string)element.Attribute(PA.Select);
+                    var match = (string)element.Attribute(PA.Match);
+                    var notMatch = (string)element.Attribute(PA.NotMatch);
+                    bool testValue;
+
+                    try
+                    {
+                        testValue = await data.EvaluateBoolAsync(selector, match, notMatch);
+                    }
+                    catch (EvaluationException e)
+                    {
+                        return CreateContextErrorMessage(element, e.Message, templateError);
+                    }
+
+                    if (testValue)
+                    {
+                        var contentTasks = element.Elements().Select(e => ContentReplacementTransformAsync(e, data, templateError));
+                        var content = await Task.WhenAll(contentTasks);
+                        return content;
+                    }
+                    return null;
+                }
+                var childNodeTasks = element.Nodes().Select(n => ContentReplacementTransformAsync(n, data, templateError));
+                return new XElement(element.Name,
+                    element.Attributes(),
+                    await Task.WhenAll(childNodeTasks));
+            }
+            return node;
+        }
+    }
+
+    public class AsyncXmlDataContext : XmlMetadataParser, IAsyncDataContext
+    {
+        private XElement _element;
+
+        public AsyncXmlDataContext(XElement data)
+        {
+            _element = data;
+        }
+
+        public async Task<IAsyncDataContext[]> EvaluateListAsync(string selector, bool optional)
+        {
+            await Task.Yield(); // make this async -- silly, but really just for testing
+            IEnumerable<XElement> repeatingData;
+            try
+            {
+                repeatingData = _element.XPathSelectElements(selector);
+            }
+            catch (XPathException e)
+            {
+                throw new EvaluationException("XPathException: " + e.Message);
+            }
+            var newContent = repeatingData.Select(d => new AsyncXmlDataContext(d)).ToArray();
+            if (!newContent.Any())
+            {
+                if (!optional)
+                    throw new EvaluationException("Repeat: Select returned no data");
+            }
+            return newContent;
+        }
+
+        public async Task<string> EvaluateTextAsync(string xPath, bool optional)
+        {
+            await Task.Yield(); // make this async -- silly, but really just for testing
+            object xPathSelectResult;
+            try
+            {
+                //support some cells in the table may not have an xpath expression.
+                if (String.IsNullOrWhiteSpace(xPath)) return String.Empty;
+
+                xPathSelectResult = _element.XPathEvaluate(xPath);
+            }
+            catch (XPathException e)
+            {
+                throw new EvaluationException("XPathException: " + e.Message, e);
+            }
+
+            if ((xPathSelectResult is IEnumerable) && !(xPathSelectResult is string))
+            {
+                var selectedData = ((IEnumerable)xPathSelectResult).Cast<XObject>();
+                if (!selectedData.Any())
+                {
+                    if (optional) return string.Empty;
+                    throw new EvaluationException(string.Format("XPath expression ({0}) returned no results", xPath));
+                }
+                if (selectedData.Count() > 1)
+                {
+                    throw new EvaluationException(string.Format("XPath expression ({0}) returned more than one node", xPath));
+                }
+
+                XObject selectedDatum = selectedData.First();
+
+                if (selectedDatum is XElement) return ((XElement)selectedDatum).Value;
+
+                if (selectedDatum is XAttribute) return ((XAttribute)selectedDatum).Value;
+            }
+
+            return xPathSelectResult.ToString();
+
+        }
+
+        public async Task<bool> EvaluateBoolAsync(string xPath, string match, string notMatch)
+        {
+            if (match == null && notMatch == null)
+                throw new EvaluationException("Conditional: Must specify either Match or NotMatch");
+            if (match != null && notMatch != null)
+                throw new EvaluationException("Conditional: Cannot specify both Match and NotMatch");
+
+            string testValue = await EvaluateTextAsync(xPath, false);
+
+            return (match != null && testValue == match) || (notMatch != null && testValue != notMatch);
+        }
+
+        public async Task ReleaseAsync()
+        {
+            await Task.Yield(); // make this async -- silly, but really just for testing
+            _element = null;
+        }
+    }
+
+    public class AssembleResult
+    {
+        public WmlDocument Document { get; private set; }
+        public bool HasErrors { get; private set; }
+
+        internal AssembleResult(WmlDocument document, bool hasErrors)
+        {
+            Document = document;
+            HasErrors = hasErrors;
+        }
+
+        public void Deconstruct(out WmlDocument document, out bool hasErrors)
+        {
+            document = Document;
+            hasErrors = HasErrors;
+        }
+    }
+}

--- a/OpenXmlPowerTools/IDataContext.cs
+++ b/OpenXmlPowerTools/IDataContext.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Lowell Stewart. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading.Tasks;
+
+namespace OpenXmlPowerTools
+{
+    public interface IDataContext : IMetadataParser
+    {
+        string EvaluateText(string selector, bool optional);
+        bool EvaluateBool(string selector, string match, string notMatch);
+        IDataContext[] EvaluateList(string selector, bool optional);
+        void Release();
+    }
+
+    public interface IAsyncDataContext : IMetadataParser
+    {
+        Task<string> EvaluateTextAsync(string selector, bool optional);
+        Task<bool> EvaluateBoolAsync(string selector, string match, string notMatch);
+        Task<IAsyncDataContext[]> EvaluateListAsync(string selector, bool optional);
+        Task ReleaseAsync();
+    }
+
+    public class EvaluationException : Exception
+    {
+        public EvaluationException() { }
+        public EvaluationException(string message) : base(message) { }
+        public EvaluationException(string message, Exception inner) : base(message, inner) { }
+    }
+
+}

--- a/OpenXmlPowerTools/IMetadataParser.cs
+++ b/OpenXmlPowerTools/IMetadataParser.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Lowell Stewart. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Xml.Linq;
+
+namespace OpenXmlPowerTools
+{
+    public interface IMetadataParser
+    {
+        string DelimiterOpen { get; }
+        string DelimiterClose { get; }
+        string EmbedOpen { get; }
+        string EmbedClose { get; }
+        XElement TransformContentToMetadata(string content);
+    }
+
+    public class MetadataParseException : Exception
+    {
+        public MetadataParseException() { }
+        public MetadataParseException(string message) : base(message) { }
+        public MetadataParseException(string message, Exception inner) : base(message, inner) { }
+    }
+
+}

--- a/OpenXmlPowerTools/MarkupSimplifier.cs
+++ b/OpenXmlPowerTools/MarkupSimplifier.cs
@@ -33,7 +33,9 @@ namespace OpenXmlPowerTools
         public bool RemoveLastRenderedPageBreak;
         public bool RemoveMarkupForDocumentComparison;
         public bool RemovePermissions;
-        public bool RemoveProof;
+        public bool RemoveProof; // now redundant and included only for backward compatibility
+        public bool RemoveProofingErrors;
+        public bool RemoveSuppressProofing;
         public bool RemoveRsidInfo;
         public bool RemoveSmartTags;
         public bool RemoveSoftHyphens;
@@ -307,9 +309,12 @@ namespace OpenXmlPowerTools
                  (element.Name == W.permStart)))
                 return null;
 
-            if (settings.RemoveProof &&
-                ((element.Name == W.proofErr) ||
-                 (element.Name == W.noProof)))
+            if ((settings.RemoveProofingErrors || settings.RemoveProof) &&
+                (element.Name == W.proofErr))
+                return null;
+
+            if ((settings.RemoveSuppressProofing || settings.RemoveProof) &&
+                (element.Name == W.noProof))
                 return null;
 
             if (settings.RemoveSoftHyphens &&
@@ -547,6 +552,8 @@ namespace OpenXmlPowerTools
                     settings.RemoveFieldCodes ||
                     settings.RemovePermissions ||
                     settings.RemoveProof ||
+                    settings.RemoveProofingErrors ||
+                    settings.RemoveSuppressProofing ||
                     settings.RemoveBookmarks ||
                     settings.RemoveWebHidden ||
                     settings.RemoveGoBackBookmark ||


### PR DESCRIPTION
Requirements on our end demanded that metadata in templates be more human readable (and less arcane) than the current XML syntax. We have implemented an abstraction that allows the current XML syntax to continue working exactly as before (all unit tests passing) but also allows alternative syntax in content controls, and correspondingly, alternative sources for the data used to assemble documents.

In addition, we have added (as an alternative) a fully asynchronous means of assembling documents, which facilitates data sources that are likewise asynchronous.

Please consider pulling these changes into your repository. I am happy to discuss any decisions or motivations, and will gladly accept feedback on how to improve these features (whether prior to or after merging).