### PR TITLE
A couple of fixes for edge cases of converting docx to html

### DIFF
--- a/OpenXmlPowerTools/FormattingAssembler.cs
+++ b/OpenXmlPowerTools/FormattingAssembler.cs
@@ -2014,8 +2014,8 @@ namespace OpenXmlPowerTools
             while (localParaStyleName != null)
             {
                 XElement paraStyle = stylesXDoc.Root.Elements(W.style).FirstOrDefault(s =>
-                    s.Attribute(W.type).Value == "paragraph" &&
-                    s.Attribute(W.styleId).Value == localParaStyleName);
+                    s.Attribute(W.type)?.Value == "paragraph" &&
+                    s.Attribute(W.styleId)?.Value == localParaStyleName);
                 if (paraStyle == null)
                 {
                     yield break;


### PR DESCRIPTION
I've encountered a couple of errors converting docx files to htmls with this lib. 

First one was in a file having `style` elements missing `type` attributes. Second one is file with font sizes specified in `pt` units like `"16pt"`. Diving into the sources i've managed to fix them. 

Examples
[1044_710.docx](https://github.com/EricWhiteDev/Open-Xml-PowerTools/files/2961536/1044_710.docx)
[1539_15-фз.docx](https://github.com/EricWhiteDev/Open-Xml-PowerTools/files/2961537/1539_15-.docx)

Unfortunately i don't have examples with these issues in english. 

