### PR TITLE
Fix for supporting slides with SVG images.

### DIFF
--- a/OpenXmlPowerTools/PresentationBuilder.cs
+++ b/OpenXmlPowerTools/PresentationBuilder.cs
@@ -635,7 +635,7 @@ namespace OpenXmlPowerTools
             IEnumerable<XElement> newContent, List<ImageData> images, List<MediaData> mediaList)
         {
             var relevantElements = newContent.DescendantsAndSelf()
-                .Where(d => d.Name == VML.imagedata || d.Name == VML.fill || d.Name == VML.stroke || d.Name == A.blip)
+                .Where(d => d.Name == VML.imagedata || d.Name == VML.fill || d.Name == VML.stroke || d.Name == A.blip || d.Name == SVG.svgBlip)
                 .ToList();
             foreach (XElement imageReference in relevantElements)
             {

--- a/OpenXmlPowerTools/PtOpenXmlUtil.cs
+++ b/OpenXmlPowerTools/PtOpenXmlUtil.cs
@@ -4179,7 +4179,11 @@ listSeparator
         public static readonly XName _pic = pic + "pic";
         public static readonly XName spPr = pic + "spPr";
     }
-
+    public static class SVG
+    {
+        public static readonly XNamespace svg = "http://schemas.microsoft.com/office/drawing/2016/SVG/main";
+        public static readonly XName svgBlip = svg + "svgBlip";
+    }
     public static class Plegacy
     {
         public static readonly XNamespace plegacy = "urn:schemas-microsoft-com:office:powerpoint";


### PR DESCRIPTION
When building a presentation from slideparts, the presentation was corrupted because the SVG was not included in the package.