### PR TITLE
Fix for crash when TextReplacer when replacement string is empty.

### DIFF
--- a/OpenXmlPowerTools/TextReplacer.cs
+++ b/OpenXmlPowerTools/TextReplacer.cs
@@ -149,7 +149,7 @@ namespace OpenXmlPowerTools
                                         return (object)g;
                                     string textValue = g.Select(r => r.Element(W.t).Value).StringConcatenate();
                                     XAttribute xs = null;
-                                    if (textValue[0] == ' ' || textValue[textValue.Length - 1] == ' ')
+                                    if (textValue.Length > 0 && (textValue[0] == ' ' || textValue[textValue.Length - 1] == ' '))
                                         xs = new XAttribute(XNamespace.Xml + "space", "preserve");
                                     return new XElement(W.r,
                                         g.First().Elements(W.rPr),

--- a/OpenXmlPowerToolsExamples/TextReplacer02/TextReplacer02.cs
+++ b/OpenXmlPowerToolsExamples/TextReplacer02/TextReplacer02.cs
@@ -20,7 +20,7 @@ namespace OpenXmlPowerTools
             var tempDi = new DirectoryInfo(string.Format("ExampleOutput-{0:00}-{1:00}-{2:00}-{3:00}{4:00}{5:00}", n.Year - 2000, n.Month, n.Day, n.Hour, n.Minute, n.Second));
             tempDi.Create();
 
-            DirectoryInfo di2 = new DirectoryInfo("../../");
+            DirectoryInfo di2 = new DirectoryInfo("../../../");
             foreach (var file in di2.GetFiles("*.docx"))
                 file.CopyTo(Path.Combine(tempDi.FullName, file.Name));
 
@@ -50,6 +50,8 @@ namespace OpenXmlPowerTools
                 TextReplacer.SearchAndReplace(doc, "the", "this", true);
             using (WordprocessingDocument doc = WordprocessingDocument.Open(Path.Combine(tempDi.FullName, "Test09.docx"), true))
                 TextReplacer.SearchAndReplace(doc, "===== Replace this text =====", "***zzz***", true);
+            using (WordprocessingDocument doc = WordprocessingDocument.Open(Path.Combine(tempDi.FullName, "Test09.docx"), true))
+                TextReplacer.SearchAndReplace(doc, "***zzz***", "", true);
         }
     }
 }


### PR DESCRIPTION
If you use the textReplacer and have the replacement string as and empty string an out of bounds exception occurs. 

I have also added and example in the TextReplacer examples.