### PR TITLE
Examples: Fixed incorrect document directory

### DIFF
--- a/OpenXmlPowerToolsExamples/TextReplacer02/TextReplacer02.cs
+++ b/OpenXmlPowerToolsExamples/TextReplacer02/TextReplacer02.cs
@@ -20,7 +20,7 @@ namespace OpenXmlPowerTools
             var tempDi = new DirectoryInfo(string.Format("ExampleOutput-{0:00}-{1:00}-{2:00}-{3:00}{4:00}{5:00}", n.Year - 2000, n.Month, n.Day, n.Hour, n.Minute, n.Second));
             tempDi.Create();
 
-            DirectoryInfo di2 = new DirectoryInfo("../../");
+            DirectoryInfo di2 = new DirectoryInfo("../../../");
             foreach (var file in di2.GetFiles("*.docx"))
                 file.CopyTo(Path.Combine(tempDi.FullName, file.Name));
 


### PR DESCRIPTION
In previous code files were not copied into 'ExampleOutput' directory, and it caused 'System.IO.FileNotFoundException: 'Could not find document' error while trying to open files from 'ExampleOutput' directory.