### PR TITLE
Update for to Create Content Control Element in WmlToHTMLConvertor

### DIFF
--- a/OpenXmlPowerTools/FieldRetriever.cs
+++ b/OpenXmlPowerTools/FieldRetriever.cs
@@ -372,6 +372,7 @@ namespace OpenXmlPowerTools
                 fieldType.ToUpper() != "REF" &&
                 fieldType.ToUpper() != "SEQ" &&
                 fieldType.ToUpper() != "STYLEREF" &&
+                fieldType.ToUpper() != "LISTNUM" &&
                 fieldType.ToUpper() != "PAGE")
                 return emptyField;
             string[] tokens = GetTokens(field);

--- a/OpenXmlPowerTools/FormattingAssembler.cs
+++ b/OpenXmlPowerTools/FormattingAssembler.cs
@@ -232,6 +232,7 @@ namespace OpenXmlPowerTools
                         );
 
                         XElement listItemRunProps = null;
+                        List<XAttribute> listItemHtmlAttributes = new List<XAttribute>();
                         int? abstractNumId = null;
                         if (listItemInfo != null)
                         {
@@ -283,9 +284,33 @@ namespace OpenXmlPowerTools
                             var listItemLvlRunProps = listItemLvl.Elements(W.rPr).FirstOrDefault();
                             listItemRunProps = MergeStyleElement(listItemLvlRunProps, mergedRunProps);
 
-                            if ((string)listItemLvl.Elements(W.numFmt).Attributes(W.val).FirstOrDefault() == "bullet")
+                            string numFmt = null;
+                            string format = null;
+                            numFmt = (string)listItemLvl.Elements(W.numFmt).Attributes(W.val).FirstOrDefault();
+
+                            if (numFmt == null)
+                            {
+                                var mcAlternativeContent = listItemLvl.Descendants(MC.AlternateContent).FirstOrDefault();
+                                if (mcAlternativeContent != null)
+                                {
+                                    var choice = mcAlternativeContent.Element(MC.Choice);
+                                    if (choice != null)
+                                    {
+                                        numFmt = (string)choice.Elements(W.numFmt).Attributes(W.val).FirstOrDefault();
+                                        format = (string)choice.Elements(W.numFmt).Attributes(W.format).FirstOrDefault();
+                                    }
+                                }
+                            }
+
+                            if (numFmt == "bullet")
                             {
                                 listItemRunProps.Elements(W.rtl).Remove();
+                                listItemHtmlAttributes.Add(
+                                    new XAttribute(PtOpenXml.HtmlStructure, "ul")
+                                );
+                                listItemHtmlAttributes.Add(
+                                    new XAttribute(PtOpenXml.HtmlStyle, "list-style-type: circle;")
+                                );
                             }
                             else
                             {
@@ -299,6 +324,46 @@ namespace OpenXmlPowerTools
                                         listItemRunProps = MergeStyleElement(new XElement(W.rPr,
                                             new XElement(W.rtl)), listItemRunProps);
                                     }
+                                }
+                                listItemHtmlAttributes.Add(
+                                    new XAttribute(PtOpenXml.HtmlStructure, "ol")
+                                );
+
+                                if (numFmt == "decimal")
+                                {
+                                    listItemHtmlAttributes.Add(
+                                        new XAttribute(PtOpenXml.HtmlStyle, "list-style-type: decimal;")
+                                    );
+                                }
+                                else if (numFmt == "lowerLetter")
+                                {
+                                    listItemHtmlAttributes.Add(
+                                        new XAttribute(PtOpenXml.HtmlStyle, "list-style-type: lower-alpha;")
+                                    );
+                                }
+                                else if (numFmt == "lowerRoman")
+                                {
+                                    listItemHtmlAttributes.Add(
+                                        new XAttribute(PtOpenXml.HtmlStyle, "list-style-type: lower-roman;")
+                                    );
+                                }
+                                else if (numFmt == "upperLetter")
+                                {
+                                    listItemHtmlAttributes.Add(
+                                        new XAttribute(PtOpenXml.HtmlStyle, "list-style-type: upper-alpha;")
+                                    );
+                                }
+                                else if (numFmt == "upperRoman")
+                                {
+                                    listItemHtmlAttributes.Add(
+                                        new XAttribute(PtOpenXml.HtmlStyle, "list-style-type: upper-roman;")
+                                    );
+                                }
+                                else if (numFmt == "custom" && format.StartsWith("0"))
+                                {
+                                    listItemHtmlAttributes.Add(
+                                        new XAttribute(PtOpenXml.HtmlStyle, "list-style-type: decimal-leading-zero;")
+                                    );
                                 }
                             }
                         }
@@ -555,6 +620,7 @@ namespace OpenXmlPowerTools
                             element.Attribute(PtOpenXml.LanguageType),
                             element.Attribute(PtOpenXml.Unid),
                             new XAttribute(PtOpenXml.AbstractNumId, abstractNumId),
+                            listItemHtmlAttributes,
                             newParaProps,
                             listItemRun,
                             tabRun,
@@ -613,6 +679,8 @@ namespace OpenXmlPowerTools
         public static XName[] PtNamesToKeep = new[] {
             PtOpenXml.FontName,
             PtOpenXml.AbstractNumId,
+            PtOpenXml.HtmlStructure,
+            PtOpenXml.HtmlStyle,
             PtOpenXml.StyleName,
             PtOpenXml.LanguageType,
             PtOpenXml.ListItemRun,

--- a/OpenXmlPowerTools/FormattingAssembler.cs
+++ b/OpenXmlPowerTools/FormattingAssembler.cs
@@ -666,7 +666,7 @@ namespace OpenXmlPowerTools
                 tabs = new XElement(W.tabs);
                 pPr.Add(tabs);
             }
-            var tabAtLeft = tabs.Elements(W.tab).FirstOrDefault(t => (int)t.Attribute(W.pos) == left);
+            var tabAtLeft = tabs.Elements(W.tab).FirstOrDefault(t => WordprocessingMLUtil.StringToTwips((string)t.Attribute(W.pos)) == left);
             if (tabAtLeft == null)
             {
                 tabs.Add(
@@ -1960,7 +1960,7 @@ namespace OpenXmlPowerTools
             var hps = higherPriorityElement.Elements().Select(e =>
                 new
                 {
-                    Pos = (int)e.Attribute(W.pos),
+                    Pos = WordprocessingMLUtil.StringToTwips((string)e.Attribute(W.pos)),
                     Pri = 1,
                     Element = e,
                 }
@@ -1968,7 +1968,7 @@ namespace OpenXmlPowerTools
             var lps = lowerPriorityElement.Elements().Select(e =>
                 new
                 {
-                    Pos = (int)e.Attribute(W.pos),
+                    Pos = WordprocessingMLUtil.StringToTwips((string)e.Attribute(W.pos)),
                     Pri = 2,
                     Element = e,
                 }
@@ -1977,7 +1977,7 @@ namespace OpenXmlPowerTools
                 .GroupBy(s => s.Pos)
                 .Select(g => g.OrderBy(s => s.Pri).First().Element)
                 .Where(e => (string)e.Attribute(W.val) != "clear")
-                .OrderBy(e => (int)e.Attribute(W.pos));
+                .OrderBy(e => WordprocessingMLUtil.StringToTwips((string)e.Attribute(W.pos)));
             var newTabs = new XElement(W.tabs, newTabElements);
             return newTabs;
         }

--- a/OpenXmlPowerTools/PtOpenXmlUtil.cs
+++ b/OpenXmlPowerTools/PtOpenXmlUtil.cs
@@ -768,6 +768,9 @@ namespace OpenXmlPowerTools
                             if (ce.Elements().Count(e => e.Name != W.rPr) != 1)
                                 return dontConsolidate;
 
+                            if (ce.Attribute(PtOpenXml.AbstractNumId) != null)
+                                return dontConsolidate;
+
                             XElement rPr = ce.Element(W.rPr);
                             string rPrString = rPr != null ? rPr.ToString(SaveOptions.None) : string.Empty;
 
@@ -5831,6 +5834,8 @@ listSeparator
         public static XName FontName = pt + "FontName";
         public static XName LanguageType = pt + "LanguageType";
         public static XName AbstractNumId = pt + "AbstractNumId";
+        public static XName HtmlStructure = pt + "HtmlStructure";
+        public static XName HtmlStyle = pt + "HtmlStyle";
         public static XName StyleName = pt + "StyleName";
         public static XName TabWidth = pt + "TabWidth";
         public static XName Leader = pt + "Leader";

--- a/OpenXmlPowerTools/PtOpenXmlUtil.cs
+++ b/OpenXmlPowerTools/PtOpenXmlUtil.cs
@@ -890,42 +890,39 @@ namespace OpenXmlPowerTools
                             IEnumerable<IEnumerable<XAttribute>> statusAtt =
                                 g.Select(r => r.Descendants(W.t).Take(1).Attributes(PtOpenXml.Status));
                             return new XElement(W.r,
+                                g.First().Attributes(),
                                 g.First().Elements(W.rPr),
                                 new XElement(W.t, statusAtt, xs, textValue));
                         }
 
                         if (g.First().Element(W.instrText) != null)
                             return new XElement(W.r,
+                                g.First().Attributes(),
                                 g.First().Elements(W.rPr),
                                 new XElement(W.instrText, xs, textValue));
                     }
 
                     if (g.First().Name == W.ins)
                     {
-#if false
-                        if (g.First().Elements(W.del).Any())
-                            return new XElement(W.ins,
-                                g.First().Attributes(),
-                                new XElement(W.del,
-                                    g.First().Elements(W.del).Attributes(),
-                                    new XElement(W.r,
-                                        g.First().Elements(W.del).Elements(W.r).Elements(W.rPr),
-                                        new XElement(W.delText, xs, textValue))));
-#endif
+                        XElement firstR = g.First().Element(W.r);
                         return new XElement(W.ins,
                             g.First().Attributes(),
                             new XElement(W.r,
+                                firstR?.Attributes(),
                                 g.First().Elements(W.r).Elements(W.rPr),
                                 new XElement(W.t, xs, textValue)));
                     }
 
                     if (g.First().Name == W.del)
+                    {
+                        XElement firstR = g.First().Element(W.r);
                         return new XElement(W.del,
                             g.First().Attributes(),
                             new XElement(W.r,
+                                firstR?.Attributes(),
                                 g.First().Elements(W.r).Elements(W.rPr),
                                 new XElement(W.delText, xs, textValue)));
-
+                    }
                     return g;
                 }));
 

--- a/OpenXmlPowerTools/PtOpenXmlUtil.cs
+++ b/OpenXmlPowerTools/PtOpenXmlUtil.cs
@@ -742,6 +742,35 @@ namespace OpenXmlPowerTools
             return false;
         }
 
+        public static int StringToTwips(string twipsOrPoints)
+        {
+            // if the pos value is in points, not twips
+            if (twipsOrPoints.EndsWith("pt"))
+            {
+                decimal decimalValue = decimal.Parse(twipsOrPoints.Substring(0, twipsOrPoints.Length - 2));
+                return (int)(decimalValue * 20);
+            }
+            return int.Parse(twipsOrPoints);
+        }
+
+        public static int? AttributeToTwips(XAttribute attribute)
+        {
+            if (attribute == null)
+            {
+                return null;
+            }
+
+            string twipsOrPoints = (string)attribute;
+
+            // if the pos value is in points, not twips
+            if (twipsOrPoints.EndsWith("pt"))
+            {
+                decimal decimalValue = decimal.Parse(twipsOrPoints.Substring(0, twipsOrPoints.Length - 2));
+                return (int)(decimalValue * 20);
+            }
+            return int.Parse(twipsOrPoints);
+        }
+
         private static readonly List<XName> AdditionalRunContainerNames = new List<XName>
         {
             W.w + "bdo",

--- a/OpenXmlPowerTools/WmlToHtmlConverter.cs
+++ b/OpenXmlPowerTools/WmlToHtmlConverter.cs
@@ -1210,7 +1210,7 @@ namespace OpenXmlPowerTools
                         : "0");
             }
 
-            var firstLine = (decimal?) ind.Attribute(W.firstLine);
+            var firstLine = WordprocessingMLUtil.AttributeToTwips(ind.Attribute(W.firstLine));
             if (firstLine != null && elementName != Xhtml.span)
             {
                 var firstLineInInches = (decimal) firstLine/1440m;
@@ -1218,7 +1218,7 @@ namespace OpenXmlPowerTools
                     string.Format(NumberFormatInfo.InvariantInfo, "{0:0.00}in", firstLineInInches));
             }
 
-            var hanging = (decimal?) ind.Attribute(W.hanging);
+            var hanging = WordprocessingMLUtil.AttributeToTwips(ind.Attribute(W.hanging));
             if (hanging != null && elementName != Xhtml.span)
             {
                 var hangingInInches = (decimal) -hanging/1440m;
@@ -1279,7 +1279,7 @@ namespace OpenXmlPowerTools
                     style.Add("line-height", string.Format(NumberFormatInfo.InvariantInfo, "{0:0.0}pt", points));
             }
 
-            var spacingAfter = suppressTrailingWhiteSpace ? 0m : (decimal?) spacing.Attribute(W.after);
+            var spacingAfter = suppressTrailingWhiteSpace ? 0 : WordprocessingMLUtil.AttributeToTwips(spacing.Attribute(W.after));
             if (spacingAfter != null)
                 style.AddIfMissing("margin-bottom",
                     spacingAfter > 0m
@@ -1837,7 +1837,8 @@ namespace OpenXmlPowerTools
 
             // w:defaultTabStop in settings
             var sxd = wordDoc.MainDocumentPart.DocumentSettingsPart.GetXDocument();
-            var defaultTabStop = (int?)sxd.Descendants(W.defaultTabStop).Attributes(W.val).FirstOrDefault() ?? 720;
+            var defaultTabStopValue = (string)sxd.Descendants(W.defaultTabStop).Attributes(W.val).FirstOrDefault();
+            var defaultTabStop = defaultTabStopValue != null ? WordprocessingMLUtil.StringToTwips(defaultTabStopValue) : 720;
 
             var pxd = wordDoc.MainDocumentPart.GetXDocument();
             var root = pxd.Root;
@@ -1876,16 +1877,16 @@ namespace OpenXmlPowerTools
             {
                 // todo need to handle start and end attributes
 
-                var left = (int?)ind.Attribute(W.left);
+                var left = WordprocessingMLUtil.AttributeToTwips(ind.Attribute(W.left));
                 if (left != null)
                     leftInTwips = (int)left;
 
                 var firstLine = 0;
-                var firstLineAtt = (int?)ind.Attribute(W.firstLine);
+                var firstLineAtt = WordprocessingMLUtil.AttributeToTwips(ind.Attribute(W.firstLine));
                 if (firstLineAtt != null)
                     firstLine = (int)firstLineAtt;
 
-                var hangingAtt = (int?)ind.Attribute(W.hanging);
+                var hangingAtt = WordprocessingMLUtil.AttributeToTwips(ind.Attribute(W.hanging));
                 if (hangingAtt != null)
                     firstLine = -(int)hangingAtt;
 
@@ -1959,7 +1960,7 @@ namespace OpenXmlPowerTools
 
                     var tabAfterText = tabs
                         .Elements(W.tab)
-                        .FirstOrDefault(t => (int)t.Attribute(W.pos) > testAmount);
+                        .FirstOrDefault(t => WordprocessingMLUtil.StringToTwips((string)t.Attribute(W.pos)) > testAmount);
 
                     if (tabAfterText == null)
                     {
@@ -1995,14 +1996,14 @@ namespace OpenXmlPowerTools
                             new XElement(W.t, textAfterTab));
 
                         var widthOfTextAfterTab = CalcWidthOfRunInTwips(dummyRun2);
-                        var delta2 = (int)tabAfterText.Attribute(W.pos) - widthOfTextAfterTab - twipCounter;
+                        var delta2 = WordprocessingMLUtil.StringToTwips((string)tabAfterText.Attribute(W.pos)) - widthOfTextAfterTab - twipCounter;
                         if (delta2 < 0)
                             delta2 = 0;
                         currentElement.Add(
                             new XAttribute(PtOpenXml.TabWidth,
                                 string.Format(NumberFormatInfo.InvariantInfo, "{0:0.000}", (decimal)delta2 / 1440m)),
                             GetLeader(tabAfterText));
-                        twipCounter = Math.Max((int)tabAfterText.Attribute(W.pos), twipCounter + widthOfTextAfterTab);
+                        twipCounter = Math.Max(WordprocessingMLUtil.StringToTwips((string)tabAfterText.Attribute(W.pos)), twipCounter + widthOfTextAfterTab);
 
                         var lastElement = textElementsToMeasure.LastOrDefault();
                         if (lastElement == null)
@@ -2042,7 +2043,7 @@ namespace OpenXmlPowerTools
                                 new XElement(W.t, mantissa));
 
                             var widthOfMantissa = CalcWidthOfRunInTwips(dummyRun4);
-                            var delta2 = (int)tabAfterText.Attribute(W.pos) - widthOfMantissa - twipCounter;
+                            var delta2 = WordprocessingMLUtil.StringToTwips((string)tabAfterText.Attribute(W.pos)) - widthOfMantissa - twipCounter;
                             if (delta2 < 0)
                                 delta2 = 0;
                             currentElement.Add(
@@ -2057,7 +2058,7 @@ namespace OpenXmlPowerTools
                                 new XElement(W.t, decims));
 
                             var widthOfDecims = CalcWidthOfRunInTwips(dummyRun4);
-                            twipCounter = Math.Max((int)tabAfterText.Attribute(W.pos) + widthOfDecims, twipCounter + widthOfMantissa + widthOfDecims);
+                            twipCounter = Math.Max(WordprocessingMLUtil.StringToTwips((string)tabAfterText.Attribute(W.pos)) + widthOfDecims, twipCounter + widthOfMantissa + widthOfDecims);
 
                             var lastElement = textElementsToMeasure.LastOrDefault();
                             if (lastElement == null)
@@ -2077,14 +2078,14 @@ namespace OpenXmlPowerTools
                                 new XElement(W.t, textAfterTab));
 
                             var widthOfTextAfterTab = CalcWidthOfRunInTwips(dummyRun2);
-                            var delta2 = (int)tabAfterText.Attribute(W.pos) - widthOfTextAfterTab - twipCounter;
+                            var delta2 = WordprocessingMLUtil.StringToTwips((string)tabAfterText.Attribute(W.pos)) - widthOfTextAfterTab - twipCounter;
                             if (delta2 < 0)
                                 delta2 = 0;
                             currentElement.Add(
                                 new XAttribute(PtOpenXml.TabWidth,
                                     string.Format(NumberFormatInfo.InvariantInfo, "{0:0.000}", (decimal)delta2 / 1440m)),
                                 GetLeader(tabAfterText));
-                            twipCounter = Math.Max((int)tabAfterText.Attribute(W.pos), twipCounter + widthOfTextAfterTab);
+                            twipCounter = Math.Max(WordprocessingMLUtil.StringToTwips((string)tabAfterText.Attribute(W.pos)), twipCounter + widthOfTextAfterTab);
 
                             var lastElement = textElementsToMeasure.LastOrDefault();
                             if (lastElement == null)
@@ -2121,14 +2122,14 @@ namespace OpenXmlPowerTools
                             new XElement(W.t, textAfterTab));
 
                         var widthOfText = CalcWidthOfRunInTwips(dummyRun4);
-                        var delta2 = (int)tabAfterText.Attribute(W.pos) - (widthOfText / 2) - twipCounter;
+                        var delta2 = WordprocessingMLUtil.StringToTwips((string)tabAfterText.Attribute(W.pos)) - (widthOfText / 2) - twipCounter;
                         if (delta2 < 0)
                             delta2 = 0;
                         currentElement.Add(
                             new XAttribute(PtOpenXml.TabWidth,
                                 string.Format(NumberFormatInfo.InvariantInfo, "{0:0.000}", (decimal)delta2 / 1440m)),
                             GetLeader(tabAfterText));
-                        twipCounter = Math.Max((int)tabAfterText.Attribute(W.pos) + widthOfText / 2, twipCounter + widthOfText);
+                        twipCounter = Math.Max(WordprocessingMLUtil.StringToTwips((string)tabAfterText.Attribute(W.pos)) + widthOfText / 2, twipCounter + widthOfText);
 
                         var lastElement = textElementsToMeasure.LastOrDefault();
                         if (lastElement == null)
@@ -2142,12 +2143,12 @@ namespace OpenXmlPowerTools
                     }
                     if (tabVal == "left" || tabVal == "start" || tabVal == "num")
                     {
-                        var delta = (int)tabAfterText.Attribute(W.pos) - twipCounter;
+                        var delta = WordprocessingMLUtil.StringToTwips((string)tabAfterText.Attribute(W.pos)) - twipCounter;
                         currentElement.Add(
                             new XAttribute(PtOpenXml.TabWidth,
                                 string.Format(NumberFormatInfo.InvariantInfo, "{0:0.000}", (decimal)delta / 1440m)),
                             GetLeader(tabAfterText));
-                        twipCounter = (int)tabAfterText.Attribute(W.pos);
+                        twipCounter = WordprocessingMLUtil.StringToTwips((string)tabAfterText.Attribute(W.pos));
 
                         currentElementIdx++;
                         if (currentElementIdx >= contentToMeasure.Length)
@@ -2209,13 +2210,13 @@ namespace OpenXmlPowerTools
             var lastTabElement = tabs
                 .Elements(W.tab)
                 .Where(t => (string)t.Attribute(W.val) != "clear" && (string)t.Attribute(W.val) != "bar")
-                .OrderBy(t => (int)t.Attribute(W.pos))
+                .OrderBy(t => WordprocessingMLUtil.StringToTwips((string)t.Attribute(W.pos)))
                 .LastOrDefault();
             if (lastTabElement != null)
             {
                 if (defaultTabStop == 0)
                     defaultTabStop = 720;
-                var rangeStart = (int)lastTabElement.Attribute(W.pos) / defaultTabStop + 1;
+                var rangeStart = WordprocessingMLUtil.StringToTwips((string)lastTabElement.Attribute(W.pos)) / defaultTabStop + 1;
                 var tempTabs = new XElement(W.tabs,
                     tabs.Elements().Where(t => (string)t.Attribute(W.val) != "clear" && (string)t.Attribute(W.val) != "bar"),
                     Enumerable.Range(rangeStart, 100)
@@ -2223,7 +2224,7 @@ namespace OpenXmlPowerTools
                         new XAttribute(W.val, "left"),
                         new XAttribute(W.pos, r * defaultTabStop))));
                 tempTabs = new XElement(W.tabs,
-                    tempTabs.Elements().OrderBy(t => (int)t.Attribute(W.pos)));
+                    tempTabs.Elements().OrderBy(t => WordprocessingMLUtil.StringToTwips((string)t.Attribute(W.pos))));
                 return tempTabs;
             }
             else


### PR DESCRIPTION
Update to allow WMLtoHTMLConvertor to return <cc> element for content controls. This allows for easier content control formatting with CSS. This also opens up the possibility of using JavaScript for handling them in a Web Browser Control.