### PR TITLE
(optional)Leave [memory]Stream opened for further processing

### DIFF
--- a/OpenXmlPowerTools/PtOpenXmlUtil.cs
+++ b/OpenXmlPowerTools/PtOpenXmlUtil.cs
@@ -1944,10 +1944,10 @@ listSeparator
 #if !NET35
     public static class UriFixer
     {
-        public static void FixInvalidUri(Stream fs, Func<string, Uri> invalidUriHandler)
+        public static void FixInvalidUri(Stream fs, Func<string, Uri> invalidUriHandler, bool leaveOpen = false)
         {
             XNamespace relNs = "http://schemas.openxmlformats.org/package/2006/relationships";
-            using (ZipArchive za = new ZipArchive(fs, ZipArchiveMode.Update))
+            using (ZipArchive za = new ZipArchive(fs, ZipArchiveMode.Update, leaveOpen))
             {
                 foreach (var entry in za.Entries.ToList())
                 {


### PR DESCRIPTION
I have a use case where I upload an excel file which will be writed to a memoryStream. When the XLWorkbook constructor throws the OpenXmlPackageException, I need to apply the UriFixer.FixInavlidURI method, and then keep parsing the document rows to my objects.