### PR TITLE
fix: remove direct reference

### DIFF
--- a/OpenXmlPowerToolsExamples/MarkupSimplifierApp/MarkupSimplifierApp.csproj
+++ b/OpenXmlPowerToolsExamples/MarkupSimplifierApp/MarkupSimplifierApp.csproj
@@ -7,7 +7,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\OpenXmlPowerTools\OpenXmlPowerTools.csproj" />
-    <PackageReference Include="DocumentFormat.OpenXml" Version="2.14.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Otherwise we've got a duplicate reference to `DocumentFormat.OpenXml`